### PR TITLE
don't use set -eo pipefail

### DIFF
--- a/functions
+++ b/functions
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+[[ $DOKKU_TRACE ]] && set -x
 
 # git specific implementation
 get_latest_commit_user_from_git() {

--- a/post-deploy
+++ b/post-deploy
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+[[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/functions"
 
 APP="$1"

--- a/pre-receive-app
+++ b/pre-receive-app
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+[[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/functions"
 
 APP="$1"


### PR DESCRIPTION
we are a non-critical plugin. thus we should not fail the entire deployment.
